### PR TITLE
Kong 2.0 compat

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -1,5 +1,4 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
 local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 local JWT_PLUGIN_PRIORITY = (require "kong.plugins.jwt.handler").PRIORITY
 local CLAIM_HEADERS = require "kong.plugins.jwt-claim-headers.claim_headers"

--- a/kong-jwt-claim-headers-2.0-0.rockspec
+++ b/kong-jwt-claim-headers-2.0-0.rockspec
@@ -1,8 +1,8 @@
 package = "kong-jwt-claim-headers"
-version = "1.0-1"
+version = "2.0-0"
 source = {
   url = "git://github.com/wego/kong-jwt-claim-headers",
-  tag = "v1.0.0"
+  tag = "v2.0.0"
 }
 description = {
   summary = "A Kong plugin to map JWT claims to request headers ",
@@ -11,7 +11,7 @@ description = {
 }
 dependencies = {
   "lua ~> 5.1",
-  "kong >= 0.10"
+  "kong >= 2.0.0"
 }
 build = {
   type = "builtin",

--- a/kong-jwt-claim-headers-2.0.0-1.rockspec
+++ b/kong-jwt-claim-headers-2.0.0-1.rockspec
@@ -1,5 +1,5 @@
 package = "kong-jwt-claim-headers"
-version = "2.0-0"
+version = "2.0.0-1"
 source = {
   url = "git://github.com/wego/kong-jwt-claim-headers",
   tag = "v2.0.0"


### PR DESCRIPTION
### Purpose

`kong.tools.responses` has been deprecated since 1.0.0. Entirely remove reference since it's currently unused anyway.

### Notes
- Cut new major version release compatible with newer versions of kong