### PR TITLE
feat(kong3.x): make plugin compatible with Kong 3

### DIFF
--- a/schema.lua
+++ b/schema.lua
@@ -1,6 +1,23 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 return {
-  no_consumer = true,
-  fields = {
-  	uri_param_names = {type = "array", default = {"jwt"}}
-  }
+    name = "jwt",
+    fields = {{
+        consumer = typedefs.no_consumer
+    }, {
+        protocols = typedefs.protocols_http
+    }, {
+        config = {
+            type = "record",
+            fields = {{
+                uri_param_names = {
+                    type = "set",
+                    elements = {
+                        type = "string"
+                    },
+                    default = {"jwt"}
+                }
+            }}
+        }
+    }},
 }


### PR DESCRIPTION
Kong deprecated and then removed quite a few things with version 3.x:
- [Legacy plugin schemas support removal](https://github.com/Kong/kong/blob/master/CHANGELOG.md#300)
- [BasePlugin deprecation](https://github.com/Kong/kong/blob/master/CHANGELOG.md#270)

This PR aims to make the plugin compatible. Is was highly inspired by [Kong's JWT plugin](https://github.com/Kong/kong/tree/master/kong/plugins/jwt).